### PR TITLE
Fix compile tag bug.

### DIFF
--- a/src/misaki/server.clj
+++ b/src/misaki/server.clj
@@ -47,8 +47,9 @@
           ; compile tag
           (if-let [tags (-> file get-post-options :tag)]
             (doseq [tag tags]
-              (print " * compiling tag:" tag)
-              (print-result (compile-tag tag))))))))
+              (let [{tag_name :name} tag]
+                (print " * compiling tag:" tag_name)
+                (print-result (compile-tag tag_name)))))))))
 
 ;; ## Template Watcher
 


### PR DESCRIPTION
I have files in tag directory with names like {:name python, :url /tag/python.html}.html
and messages in console:

```
 * compiling tag: {:name fp, :url /tag/fp.html} ... DONE
 * compiling tag: {:name python, :url /tag/python.html} ... DONE
```

It happens, because we pass tag object to compile_tag function, but need to pass tag's name.
