### PR TITLE
Fix issue #37: make misaki work on Windows

### DIFF
--- a/src/misaki/compiler/default/config.clj
+++ b/src/misaki/compiler/default/config.clj
@@ -61,7 +61,7 @@
   "Check whether file is layout file or not."
   [#^File file]
   {:pre [(file? file)]}
-  (str-contains? (.getAbsolutePath file) (:layout-dir *config*)))
+  (str-contains? (file-abspath file) (:layout-dir *config*)))
 
 ;; ## Converter
 

--- a/src/misaki/config.clj
+++ b/src/misaki/config.clj
@@ -136,7 +136,7 @@
   "Check whether file is post file or not."
   [#^File file]
   {:pre [(file? file)]}
-  (and (:post-dir *config*) (str-contains? (.getAbsolutePath file)
+  (and (:post-dir *config*) (str-contains? (file-abspath file)
                                            (:post-dir *config*))))
 
 ; =index-file?
@@ -208,7 +208,7 @@
 (defn- make-regular-output-filename
   "Make regular output filename from java.io.File."
   [#^File file]
-  (let [path (.getPath file)
+  (let [path (file-path file)
         len  (count (:template-dir *config*))]
     (if (.startsWith path (:template-dir *config*))
       (.substring path len)

--- a/src/misaki/util/file.clj
+++ b/src/misaki/util/file.clj
@@ -12,6 +12,12 @@
   [x]
   (= java.io.File (class x)))
 
+; =normalize-slashes
+(defn normalize-slashes
+  "Replace backslashes to forward slashes."
+  [path]
+  (str/replace path #"[\\]+" "/"))
+
 ; =normalize-path
 (defn normalize-path
   "Normalize file path.
@@ -29,6 +35,16 @@
       symbol?  (keyword ext)
       string?  (keyword (last (str/split ext #"\*\.")))
       nil)))
+
+(defn file-path
+  "Get the path of a file and normalize its slashes."
+  [#^File file]
+  (normalize-slashes (.getPath file)))
+
+(defn file-abspath
+  "Get the absolute path of a file and normalize its slashes."
+  [#^File file]
+  (normalize-slashes (.getAbsolutePath file)))
 
 ; =path
 (defn path


### PR DESCRIPTION
Sorry for the mistake in the first commit message. The issue number should be #37. This small fix is mainly to wrap .getPath and .getAbsolutePath for the java.io.File class so that the backslashes () in the Windows file paths are normalized to forward slashes (/) so that they don't mess up the computation of the output file names in make-output-filename. All tests pass as they did before the changes on both Linux and Windows.
