### PR TITLE
Fix path bug in cljs example

### DIFF
--- a/doc/.template/posts/05-clojurescript.html.clj
+++ b/doc/.template/posts/05-clojurescript.html.clj
@@ -74,4 +74,4 @@ rm -rf cljs
 SH
 
 
-(js "../js/hello.js")
+(js "/js/hello.js")


### PR DESCRIPTION
The clojurescript example seems to be broken due to a path issue. If you try to use the "Call clojurescript function!" button at http://liquidz.github.io/misaki/toc/05-clojurescript.html, nothing happens.

This is a simple fix, which just removes the ".." from the path to hello.js. Unless I'm mistaken, the issue is simply that the path is computed from the root rather than the current file's directory.
