### PR TITLE
Fix <link> entry in atom.xml.clj

### DIFF
--- a/samples/blog/template/atom.xml.clj
+++ b/samples/blog/template/atom.xml.clj
@@ -10,7 +10,7 @@
  (for [post (:posts site)]
    [:entry
     [:title   (:title post)]
-    [:link    (str (:atom-base site) (:url post))]
+    [:link    {:href (str (:atom-base site) (:url post))}]
     [:updated (date->xml-schema (:date post))]
     [:id      (str (:atom-base site) (:url post))]
     [:content {:type "html"}


### PR DESCRIPTION
`<link>http://...</link>` doesn't work on some feed reader.

`<link href="http://..." />` work well. It is valid.
